### PR TITLE
feat: dockerize

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,49 @@
+# 빌드 레이어
+FROM ubuntu:22.04 AS builder
+
+# 빌드 의존성 설치
+RUN apt update && apt install -y \
+    build-essential cmake libmicrohttpd-dev \
+    libjansson-dev libssl-dev libsrtp2-dev libsofia-sip-ua-dev \
+    libglib2.0-dev libopus-dev libogg-dev libcurl4-openssl-dev \
+    liblua5.3-dev libconfig-dev pkg-config gengetopt libtool automake autoconf \
+    libnice-dev \
+    git \
+    wget \
+    && rm -rf /var/lib/apt/lists/*
+
+# 작업 디렉토리 설정
+WORKDIR /opt/janus-gateway
+
+# 소스 코드 복사 (로컬 빌드 컨텍스트에서)
+COPY . .
+
+# 컴파일
+RUN sh autogen.sh && \
+    ./configure --prefix=/opt/janus && \
+    make -j$(nproc) && \
+    make install && \
+    make configs
+
+# 런타임 레이어
+FROM ubuntu:22.04
+
+# 런타임 의존성만 설치
+RUN apt update && apt install -y \
+    libmicrohttpd12 libjansson4 libssl3 libsrtp2-1 \
+    libsofia-sip-ua0 libglib2.0-0 libopus0 libogg0 \
+    libcurl4 liblua5.3-0 libconfig9 \ 
+    libnice10 \
+    && rm -rf /var/lib/apt/lists/*
+
+# 컴파일된 바이너리와 설정 파일만 복사
+COPY --from=builder /opt/janus /opt/janus
+
+# 환경 변수 설정
+ENV PATH="/opt/janus/bin:$PATH"
+
+# 포트 개방
+EXPOSE 8088 8089 8188 8189 10000-10010/udp
+
+# 실행 명령어
+CMD ["janus"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@ ENV PATH="/opt/janus/bin:$PATH"
 
 # 포트 개방
 EXPOSE 8088 8089 8188 8189 10000-10010/udp
+EXPOSE 8000 
 
 # 실행 명령어
 CMD ["janus"]

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -1,0 +1,72 @@
+# Docker 빌드 작업을 위한 Makefile
+# 'make' 또는 'make help'를 실행하여 사용 가능한 명령어 확인
+
+# 변수 설정
+IMAGE_NAME = janus-gateway
+IMAGE_TAG ?= latest
+REGISTRY ?= picpico-labs
+FULL_IMAGE_NAME = $(REGISTRY)/$(IMAGE_NAME):$(IMAGE_TAG)
+
+# 기본 명령 (make 실행 시)
+.PHONY: help
+help:
+	@echo "Janus Gateway Docker helper"
+	@echo ""
+	@echo "사용법:"
+	@echo "  make -f Makefile.docker docker-build       - Docker 이미지 빌드"
+	@echo "  make -f Makefile.docker docker-tag         - Git 커밋 해시로 이미지 태그 지정"
+#	@echo "  make -f Makefile.docker docker-push        - 이미지를 Docker Hub에 푸시"
+	@echo "  make -f Makefile.docker docker-run         - Janus Gateway 컨테이너 실행"
+	@echo "  make -f Makefile.docker docker-run-daemon  - 컨테이너 백그라운드 실행"
+	@echo "  make -f Makefile.docker docker-dev         - 소스 마운트된 개발 컨테이너 실행"
+	@echo "  make -f Makefile.docker docker-clean       - Docker 이미지 제거"
+	@echo ""
+	@echo "환경 변수:"
+	@echo "  IMAGE_TAG - 이미지 태그 (기본값: latest)"
+	@echo "  REGISTRY  - 레지스트리 이름 (기본값: picpic-labs)"
+
+# Docker 이미지 빌드
+.PHONY: docker-build
+docker-build:
+	docker build -t $(FULL_IMAGE_NAME) .
+
+# Docker 이미지 태그 지정 (버전 태그 추가)
+.PHONY: docker-tag
+docker-tag: docker-build
+	docker tag $(FULL_IMAGE_NAME) $(REGISTRY)/$(IMAGE_NAME):$(shell git rev-parse --short HEAD)
+
+# Docker 이미지 푸시 (Docker Hub 등에)
+# .PHONY: docker-push
+# docker-push: docker-tag
+# 	docker push $(FULL_IMAGE_NAME)
+# 	docker push $(REGISTRY)/$(IMAGE_NAME):$(shell git rev-parse --short HEAD)
+
+# Docker 컨테이너 실행
+.PHONY: docker-run
+docker-run: docker-build
+	docker run -p 8088:8088 -p 8089:8089 -p 10000-10010:10000-10010/udp $(FULL_IMAGE_NAME)
+
+# Docker 컨테이너 백그라운드 실행
+.PHONY: docker-run-daemon
+docker-run-daemon: docker-build
+	docker run -d -p 8088:8088 -p 8089:8089 -p 10000-10010:10000-10010/udp $(FULL_IMAGE_NAME)
+
+# 개발용 이미지 빌드 (builder 스테이지까지만)
+.PHONY: docker-build-dev
+docker-build-dev:
+	docker build -t $(FULL_IMAGE_NAME)-dev --target builder .
+
+# 개발용 컨테이너 실행 (소스 볼륨 마운트)
+.PHONY: docker-dev
+docker-dev: docker-build-dev
+	docker run -it --rm -v $(PWD):/opt/janus-gateway -p 8088:8088 -p 8089:8089 $(FULL_IMAGE_NAME)-dev /bin/bash
+
+# Docker 이미지 및 빌드 캐시 정리
+.PHONY: docker-clean
+docker-clean:
+	docker rmi $(FULL_IMAGE_NAME) || true
+	docker rmi $(REGISTRY)/$(IMAGE_NAME):$(shell git rev-parse --short HEAD) || true
+	docker rmi $(FULL_IMAGE_NAME)-dev || true
+
+# 이것을 기본 타겟으로 설정
+.DEFAULT_GOAL := help

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -20,6 +20,7 @@ help:
 	@echo "  make -f Makefile.docker docker-run-daemon  - 컨테이너 백그라운드 실행"
 	@echo "  make -f Makefile.docker docker-dev         - 소스 마운트된 개발 컨테이너 실행"
 	@echo "  make -f Makefile.docker docker-clean       - Docker 이미지 제거"
+	@echo "  make -f Makefile.docker docker-start-demos - Janus Gateway 데모 실행"
 	@echo ""
 	@echo "환경 변수:"
 	@echo "  IMAGE_TAG - 이미지 태그 (기본값: latest)"
@@ -44,12 +45,12 @@ docker-tag: docker-build
 # Docker 컨테이너 실행
 .PHONY: docker-run
 docker-run: docker-build
-	docker run -p 8088:8088 -p 8089:8089 -p 10000-10010:10000-10010/udp $(FULL_IMAGE_NAME)
+	docker run -p 8088:8088 -p 8089:8089 -p 8000:8000 -p 10000-10010:10000-10010/udp $(FULL_IMAGE_NAME)
 
 # Docker 컨테이너 백그라운드 실행
 .PHONY: docker-run-daemon
 docker-run-daemon: docker-build
-	docker run -d -p 8088:8088 -p 8089:8089 -p 10000-10010:10000-10010/udp $(FULL_IMAGE_NAME)
+	docker run -d -p 8088:8088 -p 8089:8089 -p 8000:8000 -p 10000-10010:10000-10010/udp $(FULL_IMAGE_NAME)
 
 # 개발용 이미지 빌드 (builder 스테이지까지만)
 .PHONY: docker-build-dev
@@ -67,6 +68,18 @@ docker-clean:
 	docker rmi $(FULL_IMAGE_NAME) || true
 	docker rmi $(REGISTRY)/$(IMAGE_NAME):$(shell git rev-parse --short HEAD) || true
 	docker rmi $(FULL_IMAGE_NAME)-dev || true
+
+# Janus Gateway 데모 실행
+.PHONY: docker-start-demos
+docker-start-demos:
+	@CONTAINER_ID=$$(docker ps | grep janus | awk '{print $$1}'); \
+	if [ -z "$$CONTAINER_ID" ]; then \
+		echo "! Start container first by docker-run"; \
+		exit 1; \
+	fi; \
+	echo "starting HTTP server ..."; \
+	docker exec -d $$CONTAINER_ID bash -c "cd /opt/janus/share/janus/html/demos && python3 -m http.server 8000"; \
+	echo "server runs on http://localhost:8000/videoroom.html"
 
 # 이것을 기본 타겟으로 설정
 .DEFAULT_GOAL := help


### PR DESCRIPTION
## Description

Dockerfile과 관련 동작을 수행하는 Makefile을 추가합니다.


```bash
make -f Makefile.docker
```

위 커맨드 입력하면 helper 표시:


```
Janus Gateway Docker helper

사용법:
  make -f Makefile.docker docker-build       - Docker 이미지 빌드
  make -f Makefile.docker docker-tag         - Git 커밋 해시로 이미지 태그 지정
  make -f Makefile.docker docker-run         - Janus Gateway 컨테이너 실행
  make -f Makefile.docker docker-run-daemon  - 컨테이너 백그라운드 실행
  make -f Makefile.docker docker-dev         - 소스 마운트된 개발 컨테이너 실행
  make -f Makefile.docker docker-clean       - Docker 이미지 제거
  make -f Makefile.docker docker-start-demos - Janus Gateway 데모 실행

환경 변수:
  IMAGE_TAG - 이미지 태그 (기본값: latest)
  REGISTRY  - 레지스트리 이름 (기본값: picpic-labs)
```

참고하여 테스트 및 이후 사용하면 됩니다.

## Test Plan

```bash
# Docker 이미지 빌드
make -f Makefile.docker docker-build

# Docker 컨테이너 실행
make -f Makefile.docker docker-run
```
위 커맨드로 서버 실행 후 HTTP 요청 보내서 동작 확인:

```bash
curl http://localhost:8088/janus/info
```

아래와 같은 형태로 응답이 와야함

```jsonc
{
   "janus": "server_info",
   "transaction": "DXA0N56FN4n",
   "name": "Janus WebRTC Server",
   "version": 1301,
   "version_string": "1.3.1",
   "author": "Meetecho s.r.l.",
   "commit-hash": "1747c8f5aedd30e463ed35047f7b80e74ee3f96b",
   "compile-time": "Sun Mar  2 09:24:25 UTC 2025",
   // ...
}
```
혹은

```bash
make -f Makefile.docker docker-start-demos
```

로 데모 페이지 테스트
