### PR TITLE
feat: Websocket 통신을 위한 docker 컨테이너 8188, 8189 포트 연결

### DIFF
--- a/Makefile.docker
+++ b/Makefile.docker
@@ -6,6 +6,7 @@ IMAGE_NAME = janus-gateway
 IMAGE_TAG ?= latest
 REGISTRY ?= picpico-labs
 FULL_IMAGE_NAME = $(REGISTRY)/$(IMAGE_NAME):$(IMAGE_TAG)
+CONTAINER_NAME = janus
 
 # 기본 명령 (make 실행 시)
 .PHONY: help
@@ -45,12 +46,12 @@ docker-tag: docker-build
 # Docker 컨테이너 실행
 .PHONY: docker-run
 docker-run: docker-build
-	docker run -p 8088:8088 -p 8089:8089 -p 8000:8000 -p 8188:8188 -p 8189:8189 -p 10000-10010:10000-10010/udp $(FULL_IMAGE_NAME)
+	docker run --name $(CONTAINER_NAME) -p 8088:8088 -p 8089:8089 -p 8000:8000 -p 8188:8188 -p 8189:8189 -p 10000-10010:10000-10010/udp $(FULL_IMAGE_NAME)
 
 # Docker 컨테이너 백그라운드 실행
 .PHONY: docker-run-daemon
 docker-run-daemon: docker-build
-	docker run -d -p 8088:8088 -p 8089:8089 -p 8000:8000 -p 8188:8188 -p 8189:8189 -p 10000-10010:10000-10010/udp $(FULL_IMAGE_NAME)
+	docker run -d --name $(CONTAINER_NAME) -p 8088:8088 -p 8089:8089 -p 8000:8000 -p 8188:8188 -p 8189:8189 -p 10000-10010:10000-10010/udp $(FULL_IMAGE_NAME)
 
 # 개발용 이미지 빌드 (builder 스테이지까지만)
 .PHONY: docker-build-dev
@@ -60,7 +61,7 @@ docker-build-dev:
 # 개발용 컨테이너 실행 (소스 볼륨 마운트)
 .PHONY: docker-dev
 docker-dev: docker-build-dev
-	docker run -it --rm -v $(PWD):/opt/janus-gateway -p 8088:8088 -p 8089:8089 -p 8188:8188 -p 8189:8189 $(FULL_IMAGE_NAME)-dev /bin/bash
+	docker run -it --name $(CONTAINER_NAME)-dev --rm -v $(PWD):/opt/janus-gateway -p 8088:8088 -p 8089:8089 -p 8188:8188 -p 8189:8189 $(FULL_IMAGE_NAME)-dev /bin/bash
 
 # Docker 이미지 및 빌드 캐시 정리
 .PHONY: docker-clean

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -45,12 +45,12 @@ docker-tag: docker-build
 # Docker 컨테이너 실행
 .PHONY: docker-run
 docker-run: docker-build
-	docker run -p 8088:8088 -p 8089:8089 -p 8000:8000 -p 10000-10010:10000-10010/udp $(FULL_IMAGE_NAME)
+	docker run -p 8088:8088 -p 8089:8089 -p 8000:8000 -p 8188:8188 -p 8189:8189 -p 10000-10010:10000-10010/udp $(FULL_IMAGE_NAME)
 
 # Docker 컨테이너 백그라운드 실행
 .PHONY: docker-run-daemon
 docker-run-daemon: docker-build
-	docker run -d -p 8088:8088 -p 8089:8089 -p 8000:8000 -p 10000-10010:10000-10010/udp $(FULL_IMAGE_NAME)
+	docker run -d -p 8088:8088 -p 8089:8089 -p 8000:8000 -p 8188:8188 -p 8189:8189 -p 10000-10010:10000-10010/udp $(FULL_IMAGE_NAME)
 
 # 개발용 이미지 빌드 (builder 스테이지까지만)
 .PHONY: docker-build-dev
@@ -60,7 +60,7 @@ docker-build-dev:
 # 개발용 컨테이너 실행 (소스 볼륨 마운트)
 .PHONY: docker-dev
 docker-dev: docker-build-dev
-	docker run -it --rm -v $(PWD):/opt/janus-gateway -p 8088:8088 -p 8089:8089 $(FULL_IMAGE_NAME)-dev /bin/bash
+	docker run -it --rm -v $(PWD):/opt/janus-gateway -p 8088:8088 -p 8089:8089 -p 8188:8188 -p 8189:8189 $(FULL_IMAGE_NAME)-dev /bin/bash
 
 # Docker 이미지 및 빌드 캐시 정리
 .PHONY: docker-clean


### PR DESCRIPTION
### Context
- janus 서버의 웹소켓 포트는 8188로 지정되어있다.
  - conf/janus.transport.websockets.jcfg.sample의 ws_port=8188
- docker run으로 컨테이너 실행시 웹소켓 포트(8188, 8189)를 모두 열어주자

### Changes
- Makefile.docker 수정
  - `docker run` 커맨드를 사용중인 docker-run, docker-run-daemon, docker-dev에서 항상 8188, 8189 포트도 열도록 수정
  - 컨테이너 실행시 이름을 `janus`로 지정. 개발용은 `janus-dev`

### Tests
1. `make -f Makefile.docker docker-run`으로 janus-gateway 실행
2. 다른 터미널에서 `wscat -c ws://localhost:8188 -s janus-protocol`으로 janus-gateway와의 websocket 연결
3. Connected가 표시되며 잘 연결되는 것 확인
4. 아무문자나 입력했을 때 아래와 같이 응답 오는 것 확인
  ```
  < {
     "janus": "error",
     "error": {
        "code": 454,
        "reason": "Invalid Janus API request - <string>(1,5): '[' or '{' expected near 'hello'"
     }
  }
  > %  
  ```
### Issue
- https://github.com/orgs/picpico-labs/projects/1/views/1?visibleFields=%5B%22Title%22%2C%22Assignees%22%2C%22Status%22%2C%22Sub-issues+progress%22%2C%22Parent+issue%22%2C186822789%5D&pane=issue&itemId=109487909&issue=picpico-labs%7Cjanus-resource-broker%7C7